### PR TITLE
https://github.com/grails3-plugins/quartz/issues/2

### DIFF
--- a/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
+++ b/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
@@ -147,7 +147,7 @@ Adds Quartz job scheduling features
 
             // delay scheduler startup to after-bootstrap stage
             if (quartzProperties['org.quartz.autoStartup']) {
-                autoStartup = quartzProperties['autoStartup'] as boolean
+                autoStartup = quartzProperties['org.quartz.autoStartup'] as boolean
             }
             if (quartzProperties['org.quartz.waitForJobsToCompleteOnShutdown']) {
                 waitForJobsToCompleteOnShutdown = quartzProperties['org.quartz.waitForJobsToCompleteOnShutdown'] as boolean


### PR DESCRIPTION
Updated Quartz Scheduler bean configuration to use quartz properties defined in the Grails configuration object.

The should allow full configuration of the scheduler via Config.groovy or application.yml.

Rob
