### PR TITLE
Added issue Management for plugin-info

### DIFF
--- a/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
+++ b/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
@@ -50,6 +50,10 @@ Adds Quartz job scheduling features
 
     // License: one of 'APACHE', 'GPL2', 'GPL3'
     def license = "APACHE"
+    
+    // Location of the plugin's issue tracker.
+    def issueManagement = [ system: "Github Issues", url: "http://github.com/grails3-plugins/quartz/issues" ]
+
 
     // Any additional developers beyond the author specified above.
     def developers = [


### PR DESCRIPTION
Took how-to from https://github.com/grails3-plugins/geb/blob/master/src/main/groovy/geb/GebGrailsPlugin.groovy

Noticed that plugin-info for quartz was not showing the issue tracker.
